### PR TITLE
Release GitHub Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,11 @@ jobs:
           cp ${{ matrix.rust_package_dir }}/target/x86_64-unknown-linux-gnu/release/lib${{ matrix.rust_package_name }}.so packing/
           cp ${{ matrix.rust_package_dir }}/target/x86_64-pc-windows-gnu/release/${{ matrix.rust_package_name }}.dll packing/
           cp ${{ matrix.packing_extra_files }} packing/
-          tar -c -f Release-${{ github.ref }}-${{ matrix.engine_name }}.zip -C packing .
+          tar -c -f Release-${{ matrix.engine_name }}.zip -C packing .
 
       - name: Upload to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: Release-${{ github.ref }}-${{ matrix.engine_name }}.zip
+          file: Release-${{ matrix.engine_name }}.zip
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Release
+    permissions: write-all
+    runs-on: ubuntu-latest
+
+    # Because we need to upload both the linux .so file & the windows .dll file in a single archive, We need to compile both of them in the same runner.
+    # We can still use a matrix for the different game engines though.
+    # Also, modifying this to work on macOS is probably impossible, as it has very weird build stuff & cross-compilation is hard on macOS.
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [ godot, unity ]
+        include:
+          - engine: godot
+            engine_name: Godot
+            rust_package_dir: TwitchEventSub-Godot
+            rust_package_name: twitchevents_godot
+            packing_extra_files: TwitchEventSub-Godot/twitchapi.gdextension
+          - engine: unity
+            engine_name: Unity
+            rust_package_dir: TwitchEventSub-Unity
+            rust_package_name: rust_unity
+            packing_extra_files: TwitchEventSub-Unity/src/TwitchEvents.cs TwitchEventSub-Unity/src/TwitchEventsFFI.cs
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # TODO: Cache
+
+
+
+      - name: Build for Linux
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-unknown-linux-gnu --no-self-update
+          cd ${{ matrix.rust_package_dir }}
+          cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Build for Windows
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-gnu --no-self-update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
+          cd ${{ matrix.rust_package_dir }}
+          cargo build --release --target x86_64-pc-windows-gnu
+
+
+
+      - name: Package to archive
+        run: | 
+          mkdir -p packing
+          cp ${{ matrix.rust_package_dir }}/target/x86_64-unknown-linux-gnu/release/lib${{ matrix.rust_package_name }}.so packing/
+          cp ${{ matrix.rust_package_dir }}/target/x86_64-pc-windows-gnu/release/${{ matrix.rust_package_name }}.dll packing/
+          cp ${{ matrix.packing_extra_files }} packing/
+          tar -c -f Release-${{ github.ref }}-${{ matrix.engine_name }}.zip -C packing .
+
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: Release-${{ github.ref }}-${{ matrix.engine_name }}.zip
+          tag: ${{ github.ref }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,6 @@ open = "5.1.4"
 simple_env_load = "0.2.0"
 #simple-logging = "2.0.2"
 log = "0.4"
-twitch_eventsub_structs = { path = "../TwitchEventSubStructs" }
-#twitch_eventsub_structs = "0.1.2"
+# When building in GitHub runner: Crate doesn't exist. So when creating a release, change this back to using the updated crates.io crate
+#twitch_eventsub_structs = { path = "../TwitchEventSubStructs" }
+twitch_eventsub_structs = "0.1.2"

--- a/TwitchEventSub-Godot/Cargo.toml
+++ b/TwitchEventSub-Godot/Cargo.toml
@@ -9,7 +9,8 @@ crate-type = ["cdylib"]
 [dependencies]
 #godot = "0.1.1"
 #twitch_eventsub = { path = "../../../Git/TwitchEventSub-rs/", features=["godot"] }
-twitch_eventsub = { git = "https://github.com/lilith645/TwitchEventSub-rs.git" }
+#twitch_eventsub = { git = "https://github.com/lilith645/TwitchEventSub-rs.git" }
+twitch_eventsub = { path = "../" }
 
 [dependencies.godot]
 git = "https://github.com/godot-rust/gdext"

--- a/TwitchEventSub-Godot/twitchapi.gdextension
+++ b/TwitchEventSub-Godot/twitchapi.gdextension
@@ -1,0 +1,14 @@
+[configuration]
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.1
+reloadable = true
+
+[libraries]
+linux.debug.x86_64 =     "res://libtwitchevents_godot.so"
+linux.release.x86_64 =   "res://libtwitchevents_godot.so"
+windows.debug.x86_64 =   "res://twitchevents_godot.dll"
+windows.release.x86_64 = "res://twitchevents_godot.dll"
+macos.debug =            "res://librust_project.dylib"
+macos.release =          "res://librust_project.dylib"
+macos.debug.arm64 =      "res://librust_project.dylib"
+macos.release.arm64 =    "res://librust_project.dylib"

--- a/TwitchEventSub-Unity/Cargo.toml
+++ b/TwitchEventSub-Unity/Cargo.toml
@@ -12,4 +12,5 @@ rand = "*"
 serde = "*"
 serde_json = "*"
 serde_derive = "*"
-twitch_eventsub = { git = "https://github.com/lilith645/TwitchEventSub-rs.git" }
+#twitch_eventsub = { git = "https://github.com/lilith645/TwitchEventSub-rs.git" }
+twitch_eventsub = { path = "../" }


### PR DESCRIPTION
Automatically build & upload on new release.

I've only tested the release build TwitchEventSub-Godot for Windows.
All the other builds *should* work, but I haven't tested them.