### PR TITLE
Allow adding subcriptions to API builder via any iterable

### DIFF
--- a/twitcheventsub/src/lib.rs
+++ b/twitcheventsub/src/lib.rs
@@ -100,8 +100,11 @@ impl TwitchEventSubApiBuilder {
     self
   }
 
-  pub fn add_subscriptions(mut self, mut subs: Vec<Subscription>) -> TwitchEventSubApiBuilder {
-    self.subscriptions.append(&mut subs);
+  pub fn add_subscriptions<I: IntoIterator<Item = Subscription>>(
+    mut self,
+    subs: I,
+  ) -> TwitchEventSubApiBuilder {
+    self.subscriptions.extend(subs);
     self
   }
 


### PR DESCRIPTION
Makes the `add_subscriptions` function slightly more ergonomic, allowing a typical rust idiom:

```rust
builder.add_subscriptions([Subscription::ChatMessage, ...])
```