### PR TITLE
Feat: Clips for broadcaster

### DIFF
--- a/twitcheventsub-structs/src/api_structs.rs
+++ b/twitcheventsub-structs/src/api_structs.rs
@@ -472,3 +472,29 @@ pub struct BadgeData {
 pub struct SetOfBadges {
   pub data: Vec<BadgeData>,
 }
+
+#[derive(Debug, Clone, Deserialise)]
+pub struct ClipDetails {
+  pub r#id: String,
+  pub url: String,
+  pub embed_url: String,
+  pub broadcaster_id: String,
+  pub broadcaster_name: String,
+  pub creator_id: String,
+  pub creator_name: String,
+  pub video_id: String,
+  pub game_id: String,
+  pub language: String,
+  pub title: String,
+  pub view_count: u32,
+  pub created_at: String,
+  pub thumbnail_url: String,
+  pub duration: u32,
+  pub vod_offset: u32,
+  pub is_featured: bool,
+}
+
+#[derive(Debug, Clone, Deserialise)]
+pub struct Clips {
+  pub data: Vec<ClipDetails>,
+}

--- a/twitcheventsub/src/lib.rs
+++ b/twitcheventsub/src/lib.rs
@@ -1014,6 +1014,26 @@ impl TwitchEventSubApi {
     .and_then(|_| Ok(()))
   }
 
+  pub fn get_clips_for_broadcaster<T: Into<String>>(
+    &mut self,
+    broadcaster_id: T,
+  ) -> Result<Clips, EventSubError> {
+    let access_token = self
+      .twitch_keys
+      .access_token
+      .clone()
+      .expect("Access token not set")
+      .get_token();
+    let client_id = self.twitch_keys.client_id.to_string();
+
+    TwitchEventSubApi::regen_token_if_401(
+      TwitchApi::get_clips(access_token, client_id, broadcaster_id),
+      &mut self.twitch_keys,
+      &self.save_locations,
+    )
+    .and_then(|x| serde_json::from_str(&x).map_err(|e| EventSubError::ParseError(e.to_string())))
+  }
+
   pub fn api_user_id(&self) -> String {
     self
       .twitch_keys

--- a/twitcheventsub/src/modules/consts.rs
+++ b/twitcheventsub/src/modules/consts.rs
@@ -21,3 +21,4 @@ pub const GET_GLOBAL_BADGES_URL: &str = "https://api.twitch.tv/helix/chat/badges
 pub const GET_EMOTE_SETS_URL: &str = "https://api.twitch.tv/helix/chat/emotes/set";
 //pub const GET_USER_EMOTES_URL: &str = " https://api.twitch.tv/helix/chat/emotes/user";
 pub const CUSTOM_REWARDS_URL: &str = "https://api.twitch.tv/helix/channel_points/custom_rewards";
+pub const GET_CLIPS_URL: &str = "https://api.twitch.tv/helix/clips";

--- a/twitcheventsub/src/modules/twitch_http.rs
+++ b/twitcheventsub/src/modules/twitch_http.rs
@@ -619,6 +619,20 @@ impl TwitchApi {
       .is_delete()
       .run()
   }
+
+  pub fn get_clips<T: Into<String>, S: Into<String>, X: Into<String>>(
+    access_token: T,
+    client_id: S,
+    broadcaster_id: X,
+  ) -> Result<String, EventSubError> {
+    let url = RequestBuilder::new()
+      .add_key_value("broadcaster_id", broadcaster_id.into())
+      .build(GET_CLIPS_URL);
+    TwitchHttpRequest::new(url)
+      .header_authorisation(access_token.into(), AuthType::Bearer)
+      .header_client_id(client_id.into())
+      .run()
+  }
 }
 
 #[derive(PartialEq, Clone, Debug)]


### PR DESCRIPTION
This allows you to fetch a list of clips for a specific broadcaster which should in theory get you enough information to replicate the play a random clip for shout outs or on another command by the user.

This solves: #17 