### PR TITLE
Update README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ loop {
 ## Building
 
 ```doc
-cargo build --release
+# Build debug binaries
+cargo build --workspace
+
+# Build release binaries
+cargo build --workspace --release
 ```
 
 ## FAQ


### PR DESCRIPTION
Right now, `cargo build --release` only builds the `twitcheventsub` package, but it's likely that the user will want to build all of the packages.
